### PR TITLE
Uso de un modelo aparte para depositar información de las cargas.

### DIFF
--- a/lib/src/models/producto_model.dart
+++ b/lib/src/models/producto_model.dart
@@ -6,6 +6,7 @@ String productModelToJson(ProductModel data) => json.encode(data.toJson());
 class ProductModel {
     ProductModel({
         this.id,
+        this.owner_id,
         this.nombre_carga = '',
         this.imagen_url,
         this.tipo = '',
@@ -18,6 +19,7 @@ class ProductModel {
     });
 
     String id;
+    String owner_id;
     String nombre_carga;
     String imagen_url;
     String tipo;
@@ -30,6 +32,7 @@ class ProductModel {
 
     factory ProductModel.fromJson(Map<String, dynamic> json) => ProductModel(
         id: json["id"],
+        owner_id: json["owner_id"],
         nombre_carga: json["nombre_carga"],
         imagen_url: json["imagen_url"],
         tipo: json["tipo"],
@@ -43,6 +46,7 @@ class ProductModel {
 
     Map<String, dynamic> toJson() => {
         //"id": id,
+        "owner_id": owner_id,
         "nombre_carga": nombre_carga,
         "imagen_url": imagen_url,
         "tipo": tipo,

--- a/lib/src/pages/products/product.dart
+++ b/lib/src/pages/products/product.dart
@@ -4,6 +4,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:proyectounderway/src/models/producto_model.dart';
 import 'package:proyectounderway/src/providers/productos_provider.dart';
 import 'package:proyectounderway/src/utils/utils.dart' as utils;
+import 'package:proyectounderway/src/utils/global_arguments.dart';
 
 class ProductoPage extends StatefulWidget {
   @override
@@ -11,6 +12,7 @@ class ProductoPage extends StatefulWidget {
 }
 
 class _ProductoPageState extends State<ProductoPage> {
+  GlobalArguments _globalArguments = GlobalArguments();
   final form_key = GlobalKey<FormState>();
   final scaffoldKey = GlobalKey<ScaffoldState>();
   ProductModel producto = new ProductModel();
@@ -209,6 +211,7 @@ class _ProductoPageState extends State<ProductoPage> {
       producto.imagen_url = await productoProvider.subirImagen(_foto);
     }
     if (producto.id == null) {
+      producto.owner_id = _globalArguments.uid;
       productoProvider.crearProducto(producto);
       mostrarSnackbar('Registro Creado');
       setState(

--- a/lib/src/providers/productos_provider.dart
+++ b/lib/src/providers/productos_provider.dart
@@ -11,15 +11,16 @@ class ProductosProvider {
   GlobalArguments _globalArguments = GlobalArguments();
 
   Future<bool> crearProducto(ProductModel producto) async {
-    final url = Uri.https(_url, 'usuarios/${_globalArguments.uid}/cargas.json');
-    final resp = await http.post(url, body: productModelToJson(producto));
-    final decodedData = json.decode(resp.body);
+    final url_detalles = Uri.https(_url, 'cargas.json');
+    final resp_detalles = await http.post(url_detalles, body: productModelToJson(producto));
+    final decodedData = json.decode(resp_detalles.body);
+
     print(decodedData);
     return true;
   }
 
   Future<List<ProductModel>> cargarProductos() async {
-    final url = Uri.https(_url, 'usuarios/${_globalArguments.uid}/cargas.json');
+    final url = Uri.https(_url, 'cargas.json');
     final resp = await http.get(url);
     final Map<String, dynamic> decodedData = json.decode(resp.body);
     final List<ProductModel> productos = new List();
@@ -28,8 +29,10 @@ class ProductosProvider {
 
     decodedData.forEach((id, prod) {
       final prodTemp = ProductModel.fromJson(prod);
-      prodTemp.id = id;
-      productos.add(prodTemp);
+      if (prodTemp.owner_id == _globalArguments.uid){
+        prodTemp.id = id;
+        productos.add(prodTemp);
+      }
     });
 
     return productos;

--- a/lib/src/providers/productos_provider.dart
+++ b/lib/src/providers/productos_provider.dart
@@ -11,9 +11,9 @@ class ProductosProvider {
   GlobalArguments _globalArguments = GlobalArguments();
 
   Future<bool> crearProducto(ProductModel producto) async {
-    final url_detalles = Uri.https(_url, 'cargas.json');
-    final resp_detalles = await http.post(url_detalles, body: productModelToJson(producto));
-    final decodedData = json.decode(resp_detalles.body);
+    final url = Uri.https(_url, 'cargas.json');
+    final resp = await http.post(url, body: productModelToJson(producto));
+    final decodedData = json.decode(resp.body);
 
     print(decodedData);
     return true;


### PR DESCRIPTION
Se han modificado los providers y el modelo de las cargas para que tengan y usen el modelo de cargas de la base de dato de Firebase.
Ahora la información de las cargas ya no se depositará dentro de la información de un usuario, sino que ahora las cargas cuentan entre su información el id del usuario propietario de la carga, lo que sirve para, al momento de listar las cargas únicamente del usuario autentificado, comparar que la id del propietario de la carga sea igual a la id del usuario autentificado, y de esa forma obtener únicamente las cargas correspondientes del usuario.